### PR TITLE
give all jsp to jspc on one time

### DIFF
--- a/src/main/java/de/mytoys/maven/plugins/jspc/JspcMojo.java
+++ b/src/main/java/de/mytoys/maven/plugins/jspc/JspcMojo.java
@@ -281,13 +281,13 @@ public class JspcMojo extends AbstractMojo {
 			jspc.setVerbose(0);
 		}
 
+		String allJsp = "";
 		for (String fileName : jspFiles) {
-			jspc.setJspFiles(fileName);
-			getLog().info("Compiling " + fileName);
-			jspc.execute();
+		  allJsp += fileName + ",";
 		}
 
-
+		jspc.setJspFiles(allJsp);
+		jspc.execute();
 		Thread.currentThread().setContextClassLoader(currentClassLoader);
 	}
 


### PR DESCRIPTION
Hello

I use this plugin since I must compile jsp with tomcat6.
But now I'm in tomcat8 and I think this plugin is slow when we have a lot of jsp (I have project with almost 3000jsp).
When I look at the code, I think it's better to give all jsp to jspc before call execute method. Actually it call execute for each jsp.
I have a little benchmark for 2700 jsp 

* version 1.1.0 : 18min
* with this PR : 3min43s

When I look at other jspc maven plugin (jasig or jetty for example), they all give jsps to jspc and call execute only one time.