### PR TITLE
add extra parameter to generate strings as char arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It has the following improvements compared to jetty-jspc-maven-plugin:
 * More descriptive error messages: Under Maven 3 this plugin shows a clear indication of what caused the error and which file it is in
 * Indication of the progress of the compilation by showing which JSP is currently being compiled
 
-The compiler used in this plugin is [Apache Jasper 8.5.8](http://search.maven.org/#artifactdetails%7Corg.apache.tomcat%7Cjasper%7C8.5.8%7Cjar).
+The compiler used in this plugin is [Apache Jasper 8.5.8](http://search.maven.org/#artifactdetails%7Corg.apache.tomcat%7Ctomcat-jasper%7C8.5.8%7Cjar).
 
 Full documentation of the goal is available at http://leonardehrenfried.github.com/jspc-maven-plugin/compile-mojo.html
 

--- a/src/main/java/io/leonard/maven/plugins/jspc/JspcMojo.java
+++ b/src/main/java/io/leonard/maven/plugins/jspc/JspcMojo.java
@@ -221,6 +221,13 @@ public class JspcMojo extends AbstractMojo {
    */
   private boolean trimSpaces;
 
+  /**
+   * Should text strings be generated as char arrays, to improve performance in some cases?
+   *
+   * @parameter default-value="false"
+   */
+  private boolean genStringAsCharArray;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (getLog().isDebugEnabled()) {
@@ -242,6 +249,7 @@ public class JspcMojo extends AbstractMojo {
       getLog().info("threads=" + threads);
       getLog().info("enableJspTagPooling=" + enableJspTagPooling);
       getLog().info("trimSpaces=" + trimSpaces);
+      getLog().info("genStringAsCharArray=" + genStringAsCharArray);
     }
     try {
       long start = System.currentTimeMillis();
@@ -340,6 +348,8 @@ public class JspcMojo extends AbstractMojo {
     jspc.setFailOnError(stopAtFirstError);
     jspc.setPoolingEnabled(enableJspTagPooling);
     jspc.setTrimSpaces(trimSpaces);
+    jspc.setGenStringAsCharArray(genStringAsCharArray);
+
 
     // JspC#setExtensions() does not exist, so
     // always set concrete list of files that will be processed.


### PR DESCRIPTION
we added an option to enable

genStringAsCharArray - Should text strings be generated as char arrays, to improve performance in some cases? Default false.

 http://tomcat.apache.org/tomcat-8.0-doc/jasper-howto.html