### PR TITLE
Fixes concurrency issues that happen to tag files when read by multiple threads

### DIFF
--- a/src/main/java/io/leonard/maven/plugins/jspc/JspCContextAccessor.java
+++ b/src/main/java/io/leonard/maven/plugins/jspc/JspCContextAccessor.java
@@ -1,0 +1,54 @@
+package io.leonard.maven.plugins.jspc;
+
+import java.io.IOException;
+
+import org.apache.jasper.JasperException;
+import org.apache.jasper.JspC;
+import org.apache.jasper.compiler.JspConfig;
+import org.apache.jasper.compiler.TldCache;
+import org.apache.jasper.servlet.JspCServletContext;
+
+public class JspCContextAccessor extends JspC {
+
+	public JspCContextAccessor() {
+		super();
+	}
+	protected void initServletContext() throws JasperException, IOException {
+		initServletContext(this.loader);
+	}
+	
+	@Override
+	protected void initServletContext(ClassLoader classLoader)
+			throws IOException, JasperException {
+		super.initServletContext(classLoader);
+	}
+
+	@Override
+	protected ClassLoader initClassLoader() throws IOException {
+		return super.initClassLoader();
+	}
+	
+	protected JspCServletContext getContext() {
+		return super.context;
+	}
+	
+	protected ClassLoader getLoader() {
+		return this.loader;
+	}
+	
+	protected void initContext(JspCContextAccessor topJspC) throws IOException, JasperException {
+		this.context = topJspC.context;
+		
+
+		scanner = topJspC.scanner;
+        initTldScanner(context, getLoader());
+
+       
+        tldCache = (TldCache) context.getAttribute(TldCache.SERVLET_CONTEXT_ATTRIBUTE_NAME);
+        rctxt = topJspC.rctxt;
+        jspConfig = new JspConfig(context);
+        tagPluginManager = topJspC.tagPluginManager;
+	}
+	
+
+}

--- a/src/test/java/io/leonard/maven/plugins/jspc/TestJspcMojo.java
+++ b/src/test/java/io/leonard/maven/plugins/jspc/TestJspcMojo.java
@@ -3,10 +3,13 @@ package io.leonard.maven.plugins.jspc;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.maven.plugin.testing.MojoRule;
-import org.junit.*;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Test {@link JspcMojo}
@@ -34,12 +37,19 @@ public class TestJspcMojo {
     // Given
     File oneJspProject = new File("target/test-classes/unit/project_one_jsp");
     Path expectedWebfrag = Paths.get("target/test-classes/unit/project_one_jsp/src/assert/webfrag.xml");
-
+    System.setProperty("line.separator", "\r\n");
     // When
     rule.executeMojo(oneJspProject, "compile");
 
     // Then
     Path webfrag = Paths.get("target/test-classes/unit/project_one_jsp/target/webfrag.xml");
-    assertThat(Files.readAllBytes(webfrag)).isEqualTo(Files.readAllBytes(expectedWebfrag));
+    
+    byte[] actualWebfrag = Files.readAllBytes(webfrag);
+	byte[] expectedWebFrag = Files.readAllBytes(expectedWebfrag);
+	String actualWebFragStr = new String(actualWebfrag).replaceAll("\n", "\r\n");
+	
+	String expectedWebFragStr = new String(expectedWebFrag);
+//	assertThat(actualWebfrag).isEqualTo(expectedWebFrag);
+	assertThat(actualWebFragStr).isEqualTo(expectedWebFragStr);
   }
 }

--- a/src/test/java/io/leonard/maven/plugins/jspc/TestJspcMojo.java
+++ b/src/test/java/io/leonard/maven/plugins/jspc/TestJspcMojo.java
@@ -37,7 +37,6 @@ public class TestJspcMojo {
     // Given
     File oneJspProject = new File("target/test-classes/unit/project_one_jsp");
     Path expectedWebfrag = Paths.get("target/test-classes/unit/project_one_jsp/src/assert/webfrag.xml");
-    System.setProperty("line.separator", "\r\n");
     // When
     rule.executeMojo(oneJspProject, "compile");
 
@@ -46,10 +45,10 @@ public class TestJspcMojo {
     
     byte[] actualWebfrag = Files.readAllBytes(webfrag);
 	byte[] expectedWebFrag = Files.readAllBytes(expectedWebfrag);
-	String actualWebFragStr = new String(actualWebfrag).replaceAll("\n", "\r\n");
+//	String actualWebFragStr = new String(actualWebfrag).replaceAll("\n", "\r\n");
 	
-	String expectedWebFragStr = new String(expectedWebFrag);
-//	assertThat(actualWebfrag).isEqualTo(expectedWebFrag);
-	assertThat(actualWebFragStr).isEqualTo(expectedWebFragStr);
+//	String expectedWebFragStr = new String(expectedWebFrag);
+	assertThat(actualWebfrag).isEqualTo(expectedWebFrag);
+//	assertThat(actualWebFragStr).isEqualTo(expectedWebFragStr);
   }
 }


### PR DESCRIPTION
We were experiencing an issue when using parallel compilation where a racing condition was causing tag files to be overwritten and become corrupted thus causing jspc to fail. In order to fix that problem a new class was added that extends the JspC and provides access to the JspCServletContext. Using the JspCServletContext we can reuse the same JspRuntimeContext for each of the Workers. Jasper has a synchronization block on the JspRuntimeContext to ensure tag files are only being processed by one thread at a time. We no longer received this random errors due to tag corruption. 

As an added bonus the tld scan also happens once since we are reusing the same scanner.