### PR TITLE
Update to Jasper 9.0.17 and add JspcMojoJDTCompiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>
     <maven.version>3.3.9</maven.version>
     <java.compilation.level>1.8</java.compilation.level>
-    <tomcat.version>9.0.12</tomcat.version>
+    <tomcat.version>9.0.17</tomcat.version>
     <maven.compiler.source>${java.compilation.level}</maven.compiler.source>
     <maven.compiler.target>${java.compilation.level}</maven.compiler.target>
   </properties>

--- a/src/main/java/org/apache/jasper/compiler/JspcMojoJDTCompiler.java
+++ b/src/main/java/org/apache/jasper/compiler/JspcMojoJDTCompiler.java
@@ -1,0 +1,461 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jasper.compiler;
+
+import java.io.*;
+import java.util.*;
+
+import org.apache.jasper.JasperException;
+import org.apache.juli.logging.*;
+import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.internal.compiler.*;
+import org.eclipse.jdt.internal.compiler.Compiler;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
+import org.eclipse.jdt.internal.compiler.env.*;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
+
+/**
+ * Based on {@link JDTCompiler}.<br>
+ * Add all Java Version in source/target
+ */
+public class JspcMojoJDTCompiler extends org.apache.jasper.compiler.Compiler {
+
+	private final Log log = LogFactory.getLog(JspcMojoJDTCompiler.class); // must not be static
+
+	 /**
+     * Compile the servlet from .java file to .class file
+     */
+    @Override
+    protected void generateClass(Map<String,SmapStratum> smaps)
+        throws FileNotFoundException, JasperException, Exception {
+
+        long t1 = 0;
+        if (log.isDebugEnabled()) {
+            t1 = System.currentTimeMillis();
+        }
+
+        final String sourceFile = ctxt.getServletJavaFileName();
+        final String outputDir = ctxt.getOptions().getScratchDir().getAbsolutePath();
+        String packageName = ctxt.getServletPackageName();
+        final String targetClassName =
+            ((packageName.length() != 0) ? (packageName + ".") : "")
+                    + ctxt.getServletClassName();
+        final ClassLoader classLoader = ctxt.getJspLoader();
+        String[] fileNames = new String[] {sourceFile};
+        String[] classNames = new String[] {targetClassName};
+        final List<JavacErrorDetail> problemList = new ArrayList<>();
+
+        class CompilationUnit implements ICompilationUnit {
+
+            private final String className;
+            private final String sourceFile;
+
+            CompilationUnit(String sourceFile, String className) {
+                this.className = className;
+                this.sourceFile = sourceFile;
+            }
+
+            @Override
+            public char[] getFileName() {
+                return sourceFile.toCharArray();
+            }
+
+            @Override
+            public char[] getContents() {
+                char[] result = null;
+                try (FileInputStream is = new FileInputStream(sourceFile);
+                        InputStreamReader isr = new InputStreamReader(
+                                is, ctxt.getOptions().getJavaEncoding());
+                        Reader reader = new BufferedReader(isr)) {
+                    char[] chars = new char[8192];
+                    StringBuilder buf = new StringBuilder();
+                    int count;
+                    while ((count = reader.read(chars, 0,
+                                                chars.length)) > 0) {
+                        buf.append(chars, 0, count);
+                    }
+                    result = new char[buf.length()];
+                    buf.getChars(0, result.length, result, 0);
+                } catch (IOException e) {
+                    log.error(Localizer.getMessage("jsp.error.compilation.source", sourceFile), e);
+                }
+                return result;
+            }
+
+            @Override
+            public char[] getMainTypeName() {
+                int dot = className.lastIndexOf('.');
+                if (dot > 0) {
+                    return className.substring(dot + 1).toCharArray();
+                }
+                return className.toCharArray();
+            }
+
+            @Override
+            public char[][] getPackageName() {
+                StringTokenizer izer =
+                    new StringTokenizer(className, ".");
+                char[][] result = new char[izer.countTokens()-1][];
+                for (int i = 0; i < result.length; i++) {
+                    String tok = izer.nextToken();
+                    result[i] = tok.toCharArray();
+                }
+                return result;
+            }
+
+            @Override
+            public boolean ignoreOptionalProblems() {
+                return false;
+            }
+        }
+
+        final INameEnvironment env = new INameEnvironment() {
+
+                @Override
+                public NameEnvironmentAnswer
+                    findType(char[][] compoundTypeName) {
+                    StringBuilder result = new StringBuilder();
+                    for (int i = 0; i < compoundTypeName.length; i++) {
+                        if(i > 0)
+                            result.append('.');
+                        result.append(compoundTypeName[i]);
+                    }
+                    return findType(result.toString());
+                }
+
+                @Override
+                public NameEnvironmentAnswer
+                    findType(char[] typeName,
+                             char[][] packageName) {
+                        StringBuilder result = new StringBuilder();
+                        int i=0;
+                        for (; i < packageName.length; i++) {
+                            if(i > 0)
+                                result.append('.');
+                            result.append(packageName[i]);
+                        }
+                        if(i > 0)
+                            result.append('.');
+                        result.append(typeName);
+                        return findType(result.toString());
+                }
+
+                private NameEnvironmentAnswer findType(String className) {
+
+                    if (className.equals(targetClassName)) {
+                        ICompilationUnit compilationUnit =
+                            new CompilationUnit(sourceFile, className);
+                        return
+                            new NameEnvironmentAnswer(compilationUnit, null);
+                    }
+
+                    String resourceName =
+                            className.replace('.', '/') + ".class";
+
+                    try (InputStream is = classLoader.getResourceAsStream(resourceName)) {
+                        if (is != null) {
+                            byte[] classBytes;
+                            byte[] buf = new byte[8192];
+                            ByteArrayOutputStream baos =
+                                new ByteArrayOutputStream(buf.length);
+                            int count;
+                            while ((count = is.read(buf, 0, buf.length)) > 0) {
+                                baos.write(buf, 0, count);
+                            }
+                            baos.flush();
+                            classBytes = baos.toByteArray();
+                            char[] fileName = className.toCharArray();
+                            ClassFileReader classFileReader =
+                                new ClassFileReader(classBytes, fileName,
+                                                    true);
+                            return
+                                new NameEnvironmentAnswer(classFileReader, null);
+                        }
+                    } catch (IOException exc) {
+                        log.error(Localizer.getMessage("jsp.error.compilation.dependent", className), exc);
+                    } catch (org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException exc) {
+                        log.error(Localizer.getMessage("jsp.error.compilation.dependent", className), exc);
+                    }
+                    return null;
+                }
+
+                private boolean isPackage(String result) {
+                    if (result.equals(targetClassName)) {
+                        return false;
+                    }
+                    String resourceName = result.replace('.', '/') + ".class";
+                    try (InputStream is =
+                        classLoader.getResourceAsStream(resourceName)) {
+                        return is == null;
+                    } catch (IOException e) {
+                        // we are here, since close on is failed. That means it was not null
+                        return false;
+                    }
+                }
+
+                @Override
+                public boolean isPackage(char[][] parentPackageName,
+                                         char[] packageName) {
+                    StringBuilder result = new StringBuilder();
+                    int i=0;
+                    if (parentPackageName != null) {
+                        for (; i < parentPackageName.length; i++) {
+                            if(i > 0)
+                                result.append('.');
+                            result.append(parentPackageName[i]);
+                        }
+                    }
+
+                    if (Character.isUpperCase(packageName[0])) {
+                        if (!isPackage(result.toString())) {
+                            return false;
+                        }
+                    }
+                    if(i > 0)
+                        result.append('.');
+                    result.append(packageName);
+
+                    return isPackage(result.toString());
+                }
+
+                @Override
+                public void cleanup() {
+                }
+
+            };
+
+        final IErrorHandlingPolicy policy =
+            DefaultErrorHandlingPolicies.proceedWithAllProblems();
+
+        final Map<String,String> settings = new HashMap<>();
+        settings.put(CompilerOptions.OPTION_LineNumberAttribute,
+                     CompilerOptions.GENERATE);
+        settings.put(CompilerOptions.OPTION_SourceFileAttribute,
+                     CompilerOptions.GENERATE);
+        settings.put(CompilerOptions.OPTION_ReportDeprecation,
+                     CompilerOptions.IGNORE);
+        if (ctxt.getOptions().getJavaEncoding() != null) {
+            settings.put(CompilerOptions.OPTION_Encoding,
+                    ctxt.getOptions().getJavaEncoding());
+        }
+        if (ctxt.getOptions().getClassDebugInfo()) {
+            settings.put(CompilerOptions.OPTION_LocalVariableAttribute,
+                         CompilerOptions.GENERATE);
+        }
+
+        // Source JVM
+        if(ctxt.getOptions().getCompilerSourceVM() != null) {
+            String opt = ctxt.getOptions().getCompilerSourceVM();
+            if(opt.equals("1.1")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_1_1);
+            } else if(opt.equals("1.2")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_1_2);
+            } else if(opt.equals("1.3")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_1_3);
+            } else if(opt.equals("1.4")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_1_4);
+            } else if(opt.equals("1.5")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_1_5);
+            } else if(opt.equals("1.6")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_1_6);
+            } else if(opt.equals("1.7")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_1_7);
+            } else if(opt.equals("1.8")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_1_8);
+            // Version format changed from Java 9 onwards.
+            // Support old format that was used in EA implementation as well
+            } else if(opt.equals("9") || opt.equals("1.9")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_9);
+            } else if(opt.equals("10")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_10);
+            } else {
+                settings.put(CompilerOptions.OPTION_Source,
+                    opt);
+            }
+        } else {
+            // Default to 1.8
+            settings.put(CompilerOptions.OPTION_Source,
+                    CompilerOptions.VERSION_1_8);
+        }
+
+        // Target JVM
+        if(ctxt.getOptions().getCompilerTargetVM() != null) {
+            String opt = ctxt.getOptions().getCompilerTargetVM();
+            if(opt.equals("1.1")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                             CompilerOptions.VERSION_1_1);
+            } else if(opt.equals("1.2")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                             CompilerOptions.VERSION_1_2);
+            } else if(opt.equals("1.3")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                             CompilerOptions.VERSION_1_3);
+            } else if(opt.equals("1.4")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                             CompilerOptions.VERSION_1_4);
+            } else if(opt.equals("1.5")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                             CompilerOptions.VERSION_1_5);
+                settings.put(CompilerOptions.OPTION_Compliance,
+                        CompilerOptions.VERSION_1_5);
+            } else if(opt.equals("1.6")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                             CompilerOptions.VERSION_1_6);
+                settings.put(CompilerOptions.OPTION_Compliance,
+                        CompilerOptions.VERSION_1_6);
+            } else if(opt.equals("1.7")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                             CompilerOptions.VERSION_1_7);
+                settings.put(CompilerOptions.OPTION_Compliance,
+                        CompilerOptions.VERSION_1_7);
+            } else if(opt.equals("1.8")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                             CompilerOptions.VERSION_1_8);
+                settings.put(CompilerOptions.OPTION_Compliance,
+                        CompilerOptions.VERSION_1_8);
+            // Version format changed from Java 9 onwards.
+            // Support old format that was used in EA implementation as well
+            } else if(opt.equals("9") || opt.equals("1.9")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                             CompilerOptions.VERSION_9);
+                settings.put(CompilerOptions.OPTION_Compliance,
+                        CompilerOptions.VERSION_9);
+            } else if(opt.equals("10")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                        CompilerOptions.VERSION_10);
+                settings.put(CompilerOptions.OPTION_Compliance,
+                        CompilerOptions.VERSION_10);
+            } else {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                        opt);
+            }
+        } else {
+            // Default to 1.8
+            settings.put(CompilerOptions.OPTION_TargetPlatform,
+                    CompilerOptions.VERSION_1_8);
+            settings.put(CompilerOptions.OPTION_Compliance,
+                    CompilerOptions.VERSION_1_8);
+        }
+
+        final IProblemFactory problemFactory =
+            new DefaultProblemFactory(Locale.getDefault());
+
+        final ICompilerRequestor requestor = new ICompilerRequestor() {
+                @Override
+                public void acceptResult(CompilationResult result) {
+                    try {
+                        if (result.hasProblems()) {
+                            IProblem[] problems = result.getProblems();
+                            for (int i = 0; i < problems.length; i++) {
+                                IProblem problem = problems[i];
+                                if (problem.isError()) {
+                                    String name =
+                                        new String(problems[i].getOriginatingFileName());
+                                    try {
+                                        problemList.add(ErrorDispatcher.createJavacError
+                                                (name, pageNodes, new StringBuilder(problem.getMessage()),
+                                                        problem.getSourceLineNumber(), ctxt));
+                                    } catch (JasperException e) {
+                                        log.error(Localizer.getMessage("jsp.error.compilation.jdtProblemError"), e);
+                                    }
+                                }
+                            }
+                        }
+                        if (problemList.isEmpty()) {
+                            ClassFile[] classFiles = result.getClassFiles();
+                            for (int i = 0; i < classFiles.length; i++) {
+                                ClassFile classFile = classFiles[i];
+                                char[][] compoundName =
+                                    classFile.getCompoundName();
+                                StringBuilder classFileName = new StringBuilder(outputDir).append('/');
+                                for (int j = 0;
+                                     j < compoundName.length; j++) {
+                                    if(j > 0)
+                                        classFileName.append('/');
+                                    classFileName.append(compoundName[j]);
+                                }
+                                byte[] bytes = classFile.getBytes();
+                                classFileName.append(".class");
+                                try (FileOutputStream fout = new FileOutputStream(
+                                        classFileName.toString());
+                                        BufferedOutputStream bos = new BufferedOutputStream(fout)) {
+                                    bos.write(bytes);
+                                }
+                            }
+                        }
+                    } catch (IOException exc) {
+                        log.error(Localizer.getMessage("jsp.error.compilation.jdt"), exc);
+                    }
+                }
+            };
+
+        ICompilationUnit[] compilationUnits =
+            new ICompilationUnit[classNames.length];
+        for (int i = 0; i < compilationUnits.length; i++) {
+            String className = classNames[i];
+            compilationUnits[i] = new CompilationUnit(fileNames[i], className);
+        }
+        CompilerOptions cOptions = new CompilerOptions(settings);
+        cOptions.parseLiteralExpressionsAsConstants = true;
+        Compiler compiler = new Compiler(env,
+                                         policy,
+                                         cOptions,
+                                         requestor,
+                                         problemFactory);
+        compiler.compile(compilationUnits);
+
+        if (!ctxt.keepGenerated()) {
+            File javaFile = new File(ctxt.getServletJavaFileName());
+            if (!javaFile.delete()) {
+                throw new JasperException(Localizer.getMessage(
+                        "jsp.warning.compiler.javafile.delete.fail", javaFile));
+            }
+        }
+
+        if (!problemList.isEmpty()) {
+            JavacErrorDetail[] jeds =
+                problemList.toArray(new JavacErrorDetail[0]);
+            errDispatcher.javacError(jeds);
+        }
+
+        if( log.isDebugEnabled() ) {
+            long t2=System.currentTimeMillis();
+            log.debug("Compiled " + ctxt.getServletJavaFileName() + " "
+                      + (t2-t1) + "ms");
+        }
+
+        if (ctxt.isPrototypeMode()) {
+            return;
+        }
+
+        // JSR45 Support
+        if (! options.isSmapSuppressed()) {
+            SmapUtil.installSmap(smaps);
+        }
+    }
+}

--- a/src/test/java/io/leonard/maven/plugins/jspc/JspcMojoTestUtils.java
+++ b/src/test/java/io/leonard/maven/plugins/jspc/JspcMojoTestUtils.java
@@ -1,0 +1,24 @@
+package io.leonard.maven.plugins.jspc;
+
+import java.io.*;
+import java.nio.file.Path;
+
+public class JspcMojoTestUtils {
+
+  public static int[] getClassVersion(Path classFilePath) throws IOException {
+    DataInputStream in = new DataInputStream(new FileInputStream(classFilePath.toFile()));
+
+    int magic = in.readInt();
+    if (magic != 0xcafebabe) {
+      System.out.println(classFilePath + " is not a valid class!");
+    }
+    int minor = in.readUnsignedShort();
+    int major = in.readUnsignedShort();
+    int[] byteCodeVersion = new int[2];
+    byteCodeVersion[0] = major;
+    byteCodeVersion[1] = minor;
+    System.out.println("Version of : " + classFilePath + ": " + major + "." + minor);
+    in.close();
+    return byteCodeVersion;
+  }
+}

--- a/src/test/java/io/leonard/maven/plugins/jspc/TestJspcMojo.java
+++ b/src/test/java/io/leonard/maven/plugins/jspc/TestJspcMojo.java
@@ -15,6 +15,8 @@ import org.junit.*;
  * Test {@link JspcMojo}
  */
 public class TestJspcMojo {
+  
+  private final static int JAVA_11_BYTECODE_VERSION = 55;
 
   @Rule
   public MojoRule rule = new MojoRule();
@@ -116,6 +118,20 @@ public class TestJspcMojo {
     String result = getWebXmlReader("project_one_jsp_httpProxy").lines().collect(Collectors.joining(System.lineSeparator()));
     String expectedResult = getExpectedWebXmlReader("project_one_jsp_httpProxy").lines().collect(Collectors.joining(System.lineSeparator()));
     assertThat(result).isEqualTo(expectedResult);
+  }
+  
+  @Test
+  public void should_return_one_compiled_jsp_in_bytecode_java11_when_executeMojo_on_project_one_jsp_compilerVersion_11() throws Exception {
+    // Given
+    File oneJspProject = new File("target/test-classes/unit/project_one_jsp_compilerVersion_11");
+
+    // When
+    rule.executeMojo(oneJspProject, "compile");
+
+    // Then
+    Path indexJspPath = Paths.get("target/test-classes/unit/project_one_jsp_compilerVersion_11/target/classes/jsp/jsp/index_jsp.class");
+    int[] byteCodeVersion = JspcMojoTestUtils.getClassVersion(indexJspPath);
+    assertThat(byteCodeVersion[0]).isEqualTo(JAVA_11_BYTECODE_VERSION);
   }
 
   private BufferedReader getExpectedWebXmlReader(String projectName) throws FileNotFoundException {

--- a/src/test/resources/unit/project_one_jsp_compilerVersion_11/pom.xml
+++ b/src/test/resources/unit/project_one_jsp_compilerVersion_11/pom.xml
@@ -16,6 +16,7 @@
         <artifactId>jspc-maven-plugin</artifactId>
         <configuration>
           <compilerVersion>11</compilerVersion>
+          <compilerClass>org.apache.jasper.compiler.JspcMojoJDTCompiler</compilerClass>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/resources/unit/project_one_jsp_compilerVersion_11/pom.xml
+++ b/src/test/resources/unit/project_one_jsp_compilerVersion_11/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.leonard.maven.plugins</groupId>
+  <artifactId>one-jsp-test</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>war</packaging>
+  <name>Test one jsp with compiler version 11</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.leonard.maven.plugins</groupId>
+        <artifactId>jspc-maven-plugin</artifactId>
+        <configuration>
+          <compilerVersion>11</compilerVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/project_one_jsp_compilerVersion_11/src/main/webapp/WEB-INF/web.xml
+++ b/src/test/resources/unit/project_one_jsp_compilerVersion_11/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app metadata-complete="true" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+         
+         
+</web-app>

--- a/src/test/resources/unit/project_one_jsp_compilerVersion_11/src/main/webapp/jsp/index.jsp
+++ b/src/test/resources/unit/project_one_jsp_compilerVersion_11/src/main/webapp/jsp/index.jsp
@@ -1,0 +1,12 @@
+<html>
+
+  <%
+    String hello = "world";
+  %>
+	
+	<body>
+		Hello <%=hello %>
+	</body>  
+
+</html>
+


### PR DESCRIPTION
This PR intent to fix #39 

* Update tomcat jasper to 9.0.17 by default.
* Add test case to reproduce the #39 issue -> use compilerVersion=11 and check byteCode is in version=55

For now the problem isn't solve because Tomcat JdtCompiler doesn't handle Java 11.
(See JdtCompiler#generateClass)

So I will open a Tomcat PR to propose a fix for Java 11 and Java 12