### PR TITLE
Update documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If the Jasper compiler version needs to be overloaded, the plugin must be config
 </build>
 ```
 
-Full documentation of the goal is available at http://leonardehrenfried.github.com/jspc-maven-plugin/compile-mojo.html
+Full documentation of the goal is available at https://leonardehrenfried.github.io/jspc-maven-plugin/compile-mojo.html
 
 ## Compatibility Matrix
 


### PR DESCRIPTION
github has changed the domain of project pages.  This update fixes the old url to point to the new github.io domain