### PR TITLE
issue-104: skipJspc property (4.x branch)

### DIFF
--- a/src/main/java/io/leonard/maven/plugins/jspc/JspcMojo.java
+++ b/src/main/java/io/leonard/maven/plugins/jspc/JspcMojo.java
@@ -284,6 +284,12 @@ public class JspcMojo extends AbstractMojo {
    */
   @Parameter(defaultValue = "true")
   private boolean strictQuoteEscaping;
+  
+  /**
+   * Set this to 'true' to bypass compilation of JSP sources. 
+   */
+  @Parameter(defaultValue = "false", property = "jspc.skip")
+  private boolean skipJspc;
 
   private Map<String, NameEnvironmentAnswer> resourcesCache = new ConcurrentHashMap<>();
 
@@ -313,7 +319,12 @@ public class JspcMojo extends AbstractMojo {
       getLog().info("compilerVersion=" + compilerVersion);
       getLog().info("compilerClass=" + compilerClass);
       getLog().info("strictQuoteEscaping=" + strictQuoteEscaping);
+      getLog().info("skip=" + skipJspc);
     }
+    if ( skipJspc ) {
+      getLog().info( "Not compiling jsp sources" );
+      return;
+    }    
     try {
       long start = System.currentTimeMillis();
 
@@ -738,3 +749,4 @@ public class JspcMojo extends AbstractMojo {
     return threads == 1 ? webXmlFragment : webXmlFragment + "." + threadIndex;
   }
 }
+

--- a/src/main/java/io/leonard/maven/plugins/jspc/JspcMojo.java
+++ b/src/main/java/io/leonard/maven/plugins/jspc/JspcMojo.java
@@ -289,7 +289,7 @@ public class JspcMojo extends AbstractMojo {
    * Set this to 'true' to bypass compilation of JSP sources. 
    */
   @Parameter(defaultValue = "false", property = "jspc.skip")
-  private boolean skipJspc;
+  private boolean skip;
 
   private Map<String, NameEnvironmentAnswer> resourcesCache = new ConcurrentHashMap<>();
 
@@ -319,9 +319,9 @@ public class JspcMojo extends AbstractMojo {
       getLog().info("compilerVersion=" + compilerVersion);
       getLog().info("compilerClass=" + compilerClass);
       getLog().info("strictQuoteEscaping=" + strictQuoteEscaping);
-      getLog().info("skip=" + skipJspc);
+      getLog().info("skip=" + skip);
     }
-    if ( skipJspc ) {
+    if ( skip ) {
       getLog().info( "Not compiling jsp sources" );
       return;
     }    


### PR DESCRIPTION
This PR will allow the plugin to be skipped by specifying `<skipJspc>true</skipJspc>` in the `<configuration>` block, or by supplying `-Djspc.skip` on the commandline.