### PR TITLE
issue-104: skipJspc property (3.x branch)

### DIFF
--- a/src/main/java/io/leonard/maven/plugins/jspc/JspcMojo.java
+++ b/src/main/java/io/leonard/maven/plugins/jspc/JspcMojo.java
@@ -285,6 +285,12 @@ public class JspcMojo extends AbstractMojo {
   @Parameter(defaultValue = "true")
   private boolean strictQuoteEscaping;
 
+  /**
+   * Set this to 'true' to bypass compilation of JSP sources. 
+   */
+  @Parameter(defaultValue = "false", property = "jspc.skip")
+  private boolean skipJspc;
+
   private Map<String, NameEnvironmentAnswer> resourcesCache = new ConcurrentHashMap<>();
 
   @Override
@@ -313,7 +319,12 @@ public class JspcMojo extends AbstractMojo {
       getLog().info("compilerVersion=" + compilerVersion);
       getLog().info("compilerClass=" + compilerClass);
       getLog().info("strictQuoteEscaping=" + strictQuoteEscaping);
+      getLog().info("skip=" + skipJspc);
     }
+    if ( skipJspc ) {
+      getLog().info( "Not compiling jsp sources" );
+      return;
+    }    
     try {
       long start = System.currentTimeMillis();
 


### PR DESCRIPTION
This PR will allow the plugin to be skipped by specifying `<skipJspc>true</skipJspc>` in the `<configuration>` block, or by supplying `-Djspc.skip` on the commandline

This branch was created off the `jspc-maven-plugin-3.2.0` tag in the leonardehrenfried repository; I didn't see a 3.x branch in that repository though so this will be merged into master ( which is the wrong place to merge it )