### PR TITLE
Allow all trimSpaces options, and expose jar scan filter options.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <version>1.7.36</version>
+    </dependency>
+
 
   </dependencies>
 

--- a/src/main/java/io/leonard/maven/plugins/jspc/JspCContextAccessor.java
+++ b/src/main/java/io/leonard/maven/plugins/jspc/JspCContextAccessor.java
@@ -2,16 +2,26 @@ package io.leonard.maven.plugins.jspc;
 
 import java.io.IOException;
 import java.util.Map;
-
-import org.apache.jasper.*;
-import org.apache.jasper.compiler.*;
+import org.apache.jasper.JasperException;
+import org.apache.jasper.JspC;
+import org.apache.jasper.compiler.JspConfig;
+import org.apache.jasper.compiler.TldCache;
 import org.apache.jasper.servlet.JspCServletContext;
+import org.apache.tomcat.JarScanner;
+import org.apache.tomcat.util.scan.StandardJarScanFilter;
+import org.apache.tomcat.util.scan.StandardJarScanner;
 import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 
 public class JspCContextAccessor extends JspC {
 
   private Map<String, NameEnvironmentAnswer> resourcesCache;
   private String compilerClass;
+
+  private String tldSkip;
+
+  private String tldScan;
+
+  private Boolean defaultTldScan;
 
   public JspCContextAccessor() {
     super();
@@ -50,6 +60,18 @@ public class JspCContextAccessor extends JspC {
     this.compilerClass = compilerClass;
   }
 
+  public void setTldSkip(String tldSkip) {
+    this.tldSkip = tldSkip;
+  }
+
+  public void setTldScan(String tldScan) {
+    this.tldScan = tldScan;
+  }
+
+  public void setDefaultTldScan(Boolean defaultTldScan) {
+    this.defaultTldScan = defaultTldScan;
+  }
+
   protected void initContext(JspCContextAccessor topJspC) {
     this.context = topJspC.context;
     scanner = topJspC.scanner;
@@ -64,5 +86,26 @@ public class JspCContextAccessor extends JspC {
   @Override
   public String getCompilerClassName() {
     return getcompilerClass();
+  }
+
+  @Override
+  protected void initTldScanner(JspCServletContext context, ClassLoader classLoader) {
+    if (tldSkip != null || tldScan != null || defaultTldScan != null) {
+      JarScanner scanner = new StandardJarScanner();
+      StandardJarScanFilter filter = new StandardJarScanFilter();
+      if (tldSkip != null) {
+        filter.setTldSkip(tldSkip);
+      }
+      if (tldScan != null) {
+        filter.setTldScan(tldScan);
+      }
+      if (defaultTldScan != null) {
+        filter.setDefaultTldScan(defaultTldScan);
+      }
+      scanner.setJarScanFilter(filter);
+      // As seen in org.apache.jasper.compiler.JarScannerFactory.getJarScanner
+      context.setAttribute(JarScanner.class.getName(), scanner);
+    }
+    super.initTldScanner(context, classLoader);
   }
 }


### PR DESCRIPTION
This PR exposes all trimSpaces options.
Previously it was a simple boolean, but Tomcat [actually supports 4 different options](https://tomcat.apache.org/tomcat-10.0-doc/jasper-howto.html#Configuration) - `true`, `false`, `single` and `extended`.
The default value if no other value is supplied remains `false` for backward compatibility.

Exposed configuration options `tldSkip`, `tldScan` and `defaultTldScan` that are passed to the [jar scan filter](https://tomcat.apache.org/tomcat-10.1-doc/config/jar-scan-filter.html#Standard_Implementation) that is used to process JARs that might contain TLD files. This can be used to speed up the build.

Finally, added support to redirect the JULI log API that Jasper uses to Maven's own log (SLF4J).
This results in a cleaner log trace for the build.